### PR TITLE
feat: add `ignore` as a synonym for hidden

### DIFF
--- a/src/languageService/getCompletionsAtPosition.ts
+++ b/src/languageService/getCompletionsAtPosition.ts
@@ -76,8 +76,8 @@ export function getCompletionsAtPositionFactory(provider: Provider): ts.Language
 			for (const node of getPossibleMembers(declaration)) {
 				for (const tag of ts.getJSDocTags(node)) {
 					const name = tag.tagName.text;
-					// If this symbol has the @hidden tag, remove
-					if (name === "hidden") modifiedEntry.remove = true;
+					// If this symbol has the @hidden or @ignore tag, remove
+					if (name === "hidden" || name === "ignore") modifiedEntry.remove = true;
 					// If this symbol has the @hideinherited tag, remove if this is an inherited node
 					if (name === "hideinherited" && node !== declaration) modifiedEntry.remove = true;
 					// If this symbol has the @(server|client|shared) tag, set boundary


### PR DESCRIPTION
JSDoc has @hidden and @ignore as synonyms and are treated the same. Plugins such as `prettier-plugin-jsdoc` will automatically change @hidden to @ignore on save, with no way to remove this functionality. This PR accepts ignore as a synonym, and will remove any method with the ignore tag just like the hidden tag does currently.